### PR TITLE
fix: Keep "useless" default comments

### DIFF
--- a/src/Neos/Flow/DefaultFlow.php
+++ b/src/Neos/Flow/DefaultFlow.php
@@ -6,6 +6,7 @@ namespace Netlogix\CodingGuidelines\Php\Neos\Flow;
 
 use Netlogix\CodingGuidelines\Php\DefaultPhp;
 use PhpCsFixer\Fixer;
+use Symplify\CodingStandard\Fixer as SymplifyFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 final class DefaultFlow
@@ -38,6 +39,8 @@ final class DefaultFlow
             Fixer\ClassNotation\ProtectedToPrivateFixer::class,
             // This may break Flow Property Mapping
             Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer::class,
+            // Keep default "TODO" comments as they usually indicate there really needs to be done something
+            SymplifyFixer\Commenting\RemoveUselessDefaultCommentFixer::class,
         ];
     }
 


### PR DESCRIPTION
Those usually indicate there needs to be done at least something, which should be handled properly by developer action and potentially notified during CI checks. But those comments must not automatically go away by CI default-cleanup steps with no notification at all.